### PR TITLE
Total carbon for year

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -13,7 +13,7 @@ class DashboardController < ApplicationController
       FootprintFacade.get_footprints(@year, current_user)
     end
     
-    @total_carbon_for_year = FootprintFacade.get_total_carbon_for_year(@year, current_user)
+    @total_carbon_for_year = FootprintFacade.get_total_carbon_for_year(@footprints)
   end
 
   def select_year

--- a/app/facades/footprint_facade.rb
+++ b/app/facades/footprint_facade.rb
@@ -12,7 +12,7 @@ class FootprintFacade
   end
 
   def self.get_user_footprint_years(current_user)
-    Footprint.get_user_footprint_years(current_user)
+    FootprintService.get_user_footprint_years(current_user)
   end
 
   def self.get_total_carbon_for_year(footprints)

--- a/app/facades/footprint_facade.rb
+++ b/app/facades/footprint_facade.rb
@@ -12,13 +12,10 @@ class FootprintFacade
   end
 
   def self.get_user_footprint_years(current_user)
-    FootprintService.get_user_footprint_years(current_user)
+    Footprint.get_user_footprint_years(current_user)
   end
 
-  def self.get_total_carbon_for_year(year, current_user)
-    footprints = get_footprints(year, current_user)
-    footprints.sum do |_, carbon_in_kg|
-      carbon_in_kg
-    end
+  def self.get_total_carbon_for_year(footprints)
+    Footprint.total_carbon_for_year(footprints)
   end
 end

--- a/app/poros/footprint.rb
+++ b/app/poros/footprint.rb
@@ -8,4 +8,10 @@ class Footprint
     @year = year
     @carbon_in_kg = footprint_info[:carbonInKg] ? footprint_info[:carbonInKg] : 0
   end
+
+  def self.total_carbon_for_year(footprints)
+    footprints.sum do |footprint|
+      footprint[1]
+    end
+  end
 end

--- a/spec/facades/footprint_facade_spec.rb
+++ b/spec/facades/footprint_facade_spec.rb
@@ -51,10 +51,11 @@ RSpec.describe FootprintFacade do
   it 'Returns the sum of carbon in kg for the year' do
     year = '2021'
     current_user = create(:user)
-    file = File.read('spec/fixtures/get_footprints.json')
-    footprints = JSON.parse(file, symbolize_names: true)[:data][:fetchUserAggregateFootprintForYear][:footprints]
-    allow(FootprintService).to receive(:get_footprints).with(year, current_user).and_return(footprints)
-    result = FootprintFacade.get_total_carbon_for_year(year, current_user)
+    footprints = [["January", 20.0], ["February", 20],["March", 20],
+    ["April", 20],["May", 20.2],["June", 20],["July", 10.5],
+    ["August", 10],["September", 10],["October", 10],["November", 10],
+    ["December", 10]]
+    result = FootprintFacade.get_total_carbon_for_year(footprints)
     expect(result).to be_a(Float)
   end
 end

--- a/spec/poros/footprint_spec.rb
+++ b/spec/poros/footprint_spec.rb
@@ -19,4 +19,15 @@ describe Footprint do
 
     expect(footprint_poro.carbon_in_kg).to eq(0)
   end
+
+  it 'can calculate the total carbon for footprints' do 
+    footprints = [["January", 10], ["February", 10],["March", 10],
+    ["April", 10],["May", 10],["June", 10],["July", 10],
+    ["August", 10],["September", 10],["October", 10],["November", 10],
+    ["December", 10]]
+
+    result = Footprint.total_carbon_for_year(footprints)
+
+    expect(result).to eq(120)
+  end
 end


### PR DESCRIPTION
Change get_total_carbon_for_year 
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR changes the FootprintFacade method get_total_carbon_for_year so that it is not making an additional api call. Instead, it receives the previous api call data and calculates the sum for the year in the Footprint poro. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This change is required to make our code more efficient - not to double dip with an api call. 
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
This has been tested at the poro level. All tests pass. 100% coverage. 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] I have updated the README to reflect any changes.
