### PR TITLE
Add round to total_carbon_for_year

### DIFF
--- a/app/poros/footprint.rb
+++ b/app/poros/footprint.rb
@@ -12,6 +12,6 @@ class Footprint
   def self.total_carbon_for_year(footprints)
     footprints.sum do |footprint|
       footprint[1]
-    end
+    end.round(2)
   end
 end

--- a/spec/poros/footprint_spec.rb
+++ b/spec/poros/footprint_spec.rb
@@ -30,4 +30,14 @@ describe Footprint do
 
     expect(result).to eq(120)
   end
+
+  it 'can round the total carbon footprints' do 
+    footprints = [["January", 10.22222222222222], ["February", 10],["March", 10],
+    ["April", 10],["May", 10],["June", 10],["July", 10],
+    ["August", 10],["September", 10],["October", 10],["November", 10],
+    ["December", 10]]
+
+    result = Footprint.total_carbon_for_year(footprints)
+    expect(result).to eq(120.22)
+  end
 end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Adds rounding to the footprint PORO

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We don't want to display a very large total carbon count for the year. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
This has been tested and passes. 
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] I have updated the README to reflect any changes.
